### PR TITLE
feat: Expose certificate metrics

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -36,10 +36,10 @@ func NewGoCertRouter(env *Environment) http.Handler {
 	router.Handle("/api/v1/", http.StripPrefix("/api/v1", apiV1Router))
 	router.Handle("/", frontendHandler)
 
-	ctx := MiddlewareContext{metrics: m}
+	ctx := middlewareContext{metrics: m}
 	middleware := createMiddlewareStack(
-		Metrics(&ctx),
-		Logging(&ctx),
+		metricsMiddleware(&ctx),
+		loggingMiddleware(&ctx),
 	)
 	return middleware(router)
 }

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -3,13 +3,17 @@ package server
 import (
 	"log"
 	"net/http"
+	"strings"
+
+	"github.com/canonical/gocert/internal/metrics"
 )
 
 type Middleware func(http.Handler) http.Handler
 
-// The Context type helps middleware pass along information through the chain.
-type Context struct {
+// The MiddlewareContext type helps middleware pass along information through the chain.
+type MiddlewareContext struct {
 	responseStatusCode int
+	metrics            *metrics.PrometheusMetrics
 }
 
 // The ResponseWriterCloner struct implements the http.ResponseWriter class, and copies the status
@@ -30,20 +34,41 @@ func (rwc *ResponseWriterCloner) WriteHeader(code int) {
 	rwc.ResponseWriter.WriteHeader(code)
 }
 
+// createMiddlewareStack chains given middleware for the server.
+// Each middleware functions calls next.ServeHTTP in order to resume the chain of execution.
+// The order these functions are given to createMiddlewareStack matters.
+// The functions will run the code before next.ServeHTTP in order.
+// The functions will run the code after next.ServeHTTP in reverse order.
+func createMiddlewareStack(middleware ...Middleware) Middleware {
+	return func(next http.Handler) http.Handler {
+		for i := len(middleware) - 1; i >= 0; i-- {
+			mw := middleware[i]
+			next = mw(next)
+		}
+		return next
+	}
+}
+
 // The Metrics middleware captures any request relevant to a metric and records it for prometheus.
-func Metrics(ctx *Context) Middleware {
+func Metrics(ctx *MiddlewareContext) Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			next.ServeHTTP(w, r)
-			if ctx.responseStatusCode != 200 {
+			if ctx.responseStatusCode/100 != 2 {
 				return
+			}
+			if r.Method == "POST" && r.URL.Path == "/api/v1/certificate_requests" {
+				ctx.metrics.CertificateRequests.Inc()
+			}
+			if r.Method == "DELETE" && strings.HasPrefix(r.URL.Path, "/api/v1/certificate_requests") {
+				ctx.metrics.CertificateRequests.Dec()
 			}
 		})
 	}
 }
 
 // The logging middleware captures any http request coming through, and logs it.
-func Logging(ctx *Context) Middleware {
+func Logging(ctx *MiddlewareContext) Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			clonedWwriter := NewResponseWriter(w)

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"log"
+	"net/http"
+)
+
+type Middleware func(http.Handler) http.Handler
+
+// The Context type helps middleware pass along information through the chain.
+type Context struct {
+	responseStatusCode int
+}
+
+// The ResponseWriterCloner struct implements the http.ResponseWriter class, and copies the status
+// code of the response for the middleware to be able to read the responses.
+type ResponseWriterCloner struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+// NewResponseWriter returns a new ResponseWriterCloner struct
+func NewResponseWriter(w http.ResponseWriter) *ResponseWriterCloner {
+	return &ResponseWriterCloner{w, http.StatusOK}
+}
+
+// WriteHeader duplicates the status code into the cloner struct for reading
+func (rwc *ResponseWriterCloner) WriteHeader(code int) {
+	rwc.statusCode = code
+	rwc.ResponseWriter.WriteHeader(code)
+}
+
+// The Metrics middleware captures any request relevant to a metric and records it for prometheus.
+func Metrics(ctx *Context) Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+			if ctx.responseStatusCode != 200 {
+				return
+			}
+		})
+	}
+}
+
+// The logging middleware captures any http request coming through, and logs it.
+func Logging(ctx *Context) Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			clonedWwriter := NewResponseWriter(w)
+			next.ServeHTTP(w, r)
+			log.Println(r.Method, r.URL.Path, clonedWwriter.statusCode, http.StatusText(clonedWwriter.statusCode))
+			ctx.responseStatusCode = clonedWwriter.statusCode
+		})
+	}
+}

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -1,0 +1,1 @@
+package server_test

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -1,1 +1,0 @@
-package server_test

--- a/internal/certdb/validation.go
+++ b/internal/certdb/validation.go
@@ -22,6 +22,7 @@ func ValidateCertificateRequest(csr string) error {
 	if err != nil {
 		return err
 	}
+	// TODO: We should validate the actual certificate request parameters here too. (Has the required fields etc)
 	return nil
 }
 
@@ -40,6 +41,7 @@ func ValidateCertificate(cert string) error {
 	if err != nil {
 		return err
 	}
+	// TODO: We should validate the actual certificate parameters here too. (Has the required fields etc)
 	return nil
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -34,9 +34,9 @@ type PrometheusMetrics struct {
 func NewMetricsSubsystem(db *certdb.CertificateRequestsRepository) *PrometheusMetrics {
 	metricsBackend := newPrometheusMetrics()
 	metricsBackend.Handler = promhttp.HandlerFor(metricsBackend.registry, promhttp.HandlerOpts{})
+	ticker := time.NewTicker(120 * time.Second)
 	go func() {
-		ticker := time.NewTicker(120 * time.Second)
-		for ; true; <-ticker.C {
+		for ; ; <-ticker.C {
 			csrs, err := db.RetrieveAll()
 			if err != nil {
 				log.Println(errors.Join(errors.New("error generating metrics repository: "), err))

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -134,79 +134,63 @@ func (pm *PrometheusMetrics) generateMetrics(csrs []certdb.CertificateRequest) {
 
 func certificateRequestsMetric() prometheus.Gauge {
 	metric := prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "TODO",
-		Subsystem: "TODO",
-		Name:      "certificate_requests",
-		Help:      "Total number of certificate requests",
+		Name: "certificate_requests",
+		Help: "Total number of certificate requests",
 	})
 	return metric
 }
 
 func outstandingCertificateRequestsMetric() prometheus.Gauge {
 	metric := prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "TODO",
-		Subsystem: "TODO",
-		Name:      "outstanding_certificate_requests",
-		Help:      "Number of outstanding certificate requests",
+		Name: "outstanding_certificate_requests",
+		Help: "Number of outstanding certificate requests",
 	})
 	return metric
 }
 
 func certificatesMetric() prometheus.Gauge {
 	metric := prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "TODO",
-		Subsystem: "TODO",
-		Name:      "certificates",
-		Help:      "Total number of certificates provided to certificate requests",
+		Name: "certificates",
+		Help: "Total number of certificates provided to certificate requests",
 	})
 	return metric
 }
 
 func expiredCertificatesMetric() prometheus.Gauge {
 	metric := prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "TODO",
-		Subsystem: "TODO",
-		Name:      "certificates_expired",
-		Help:      "Number of expired certificates",
+		Name: "certificates_expired",
+		Help: "Number of expired certificates",
 	})
 	return metric
 }
 
 func certificatesExpiringIn1DayMetric() prometheus.Gauge {
 	metric := prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "TODO",
-		Subsystem: "TODO",
-		Name:      "certificates_expiring_in_1_day",
-		Help:      "Number of certificates expiring in less than 1 day",
+		Name: "certificates_expiring_in_1_day",
+		Help: "Number of certificates expiring in less than 1 day",
 	})
 	return metric
 }
 
 func certificatesExpiringIn7DaysMetric() prometheus.Gauge {
 	metric := prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "TODO",
-		Subsystem: "TODO",
-		Name:      "certificates_expiring_in_7_days",
-		Help:      "Number of certificates expiring in less than 7 days",
+		Name: "certificates_expiring_in_7_days",
+		Help: "Number of certificates expiring in less than 7 days",
 	})
 	return metric
 }
 func certificatesExpiringIn30DaysMetric() prometheus.Gauge {
 	metric := prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "TODO",
-		Subsystem: "TODO",
-		Name:      "certificates_expiring_in_30_days",
-		Help:      "Number of certificates expiring in less than 30 days",
+		Name: "certificates_expiring_in_30_days",
+		Help: "Number of certificates expiring in less than 30 days",
 	})
 	return metric
 }
 
 func certificatesExpiringIn90DaysMetric() prometheus.Gauge {
 	metric := prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "TODO",
-		Subsystem: "TODO",
-		Name:      "certificates_expiring_in_90_days",
-		Help:      "Number of certificates expiring in less than 90 days",
+		Name: "certificates_expiring_in_90_days",
+		Help: "Number of certificates expiring in less than 90 days",
 	})
 	return metric
 }
@@ -224,11 +208,9 @@ func requestsTotalMetric() prometheus.CounterVec {
 func requestDurationMetric() prometheus.HistogramVec {
 	metric := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: "TODO",
-			Subsystem: "TODO",
-			Name:      "http_request_duration_seconds",
-			Help:      "Tracks the latencies for HTTP requests.",
-			Buckets:   prometheus.ExponentialBuckets(0.1, 1.5, 5),
+			Name:    "http_request_duration_seconds",
+			Help:    "Tracks the latencies for HTTP requests.",
+			Buckets: prometheus.ExponentialBuckets(0.1, 1.5, 5),
 		}, []string{"method", "code"},
 	)
 	return *metric

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -30,7 +30,7 @@ type PrometheusMetrics struct {
 	RequestsDuration prometheus.HistogramVec
 }
 
-// NewMetricsSubsystem returns the metrics endpoint HTTP handler and the Prometheus metrics for the server and middleware.
+// NewMetricsSubsystem returns the metrics endpoint HTTP handler and the Prometheus metrics collectors for the server and middleware.
 func NewMetricsSubsystem(db *certdb.CertificateRequestsRepository) *PrometheusMetrics {
 	metricsBackend := newPrometheusMetrics()
 	metricsBackend.Handler = promhttp.HandlerFor(metricsBackend.registry, promhttp.HandlerOpts{})

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,17 +1,201 @@
 package metrics
 
 import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"log"
 	"net/http"
+	"time"
 
+	"github.com/canonical/gocert/internal/certdb"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+type PrometheusMetrics struct {
+	http.Handler
+	registry                       *prometheus.Registry
+	CertificateRequests            prometheus.Gauge
+	OutstandingCertificateRequests prometheus.Gauge
+	Certificates                   prometheus.Gauge
+	CertificatesExpiringIn1Day     prometheus.Gauge
+	CertificatesExpiringIn7Days    prometheus.Gauge
+	CertificatesExpiringIn30Days   prometheus.Gauge
+	CertificatesExpiringIn90Days   prometheus.Gauge
+	ExpiredCertificates            prometheus.Gauge
+}
+
 // Returns an HTTP handler for Prometheus metrics.
-func NewPrometheusMetricsHandler() http.Handler {
-	reg := prometheus.NewRegistry()
-	reg.MustRegister(collectors.NewGoCollector(), collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
-	prometheusHandler := promhttp.HandlerFor(reg, promhttp.HandlerOpts{})
-	return prometheusHandler
+func NewMetricsSubsystem(db *certdb.CertificateRequestsRepository) *PrometheusMetrics {
+	metricsBackend, err := newPrometheusMetrics(db)
+	if err != nil {
+		log.Println(errors.Join(errors.New("error generating metrics repository: "), err))
+	}
+	metricsBackend.Handler = promhttp.HandlerFor(metricsBackend.registry, promhttp.HandlerOpts{})
+	return metricsBackend
+}
+
+// Returns the metrics that prometheus needs to collect
+func newPrometheusMetrics(db *certdb.CertificateRequestsRepository) (*PrometheusMetrics, error) {
+	csrs, err := db.RetrieveAll()
+	if err != nil {
+		return nil, errors.Join(errors.New("could not retrieve certs for metrics: "), err)
+	}
+	m := &PrometheusMetrics{
+		registry:                       prometheus.NewRegistry(),
+		CertificateRequests:            certificateRequestsMetric(),
+		OutstandingCertificateRequests: outstandingCertificateRequestsMetric(),
+		Certificates:                   certificatesMetric(),
+		ExpiredCertificates:            expiredCertificatesMetric(),
+		CertificatesExpiringIn1Day:     certificatesExpiringIn1DayMetric(),
+		CertificatesExpiringIn7Days:    certificatesExpiringIn7DaysMetric(),
+		CertificatesExpiringIn30Days:   certificatesExpiringIn30DaysMetric(),
+		CertificatesExpiringIn90Days:   certificatesExpiringIn90DaysMetric(),
+	}
+	m.registry.MustRegister(m.CertificateRequests)
+	m.registry.MustRegister(m.OutstandingCertificateRequests)
+	m.registry.MustRegister(m.Certificates)
+	m.registry.MustRegister(m.ExpiredCertificates)
+	m.registry.MustRegister(m.CertificatesExpiringIn1Day)
+	m.registry.MustRegister(m.CertificatesExpiringIn7Days)
+	m.registry.MustRegister(m.CertificatesExpiringIn30Days)
+	m.registry.MustRegister(m.CertificatesExpiringIn90Days)
+
+	m.generateMetrics(csrs)
+	// m.registry.MustRegister(collectors.NewGoCollector())
+	// m.registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+	return m, nil
+}
+
+func (pm *PrometheusMetrics) generateMetrics(csrs []certdb.CertificateRequest) {
+	// TODO: This can run every 24 hours also to make sure we update the expiring in X day metrics.
+	var csrCount int = len(csrs)
+	var outstandingCSRCount int
+	var certCount int
+	var expiredCertCount int
+	var expiringIn1DayCertCount int
+	var expiringIn7DaysCertCount int
+	var expiringIn30DaysCertCount int
+	var expiringIn90DaysCertCount int
+	for _, entry := range csrs {
+		if entry.Certificate == "" {
+			outstandingCSRCount += 1
+		}
+		if entry.Certificate != "" && entry.Certificate != "rejected" {
+			certCount += 1
+		}
+		expiryDate := certificateExpiryDate(entry.Certificate)
+		daysRemaining := time.Until(expiryDate).Hours() / 24
+		if daysRemaining < 0 {
+			expiredCertCount += 1
+		} else {
+			if daysRemaining < 1 {
+				expiringIn1DayCertCount += 1
+			}
+			if daysRemaining < 7 {
+				expiringIn7DaysCertCount += 1
+			}
+			if daysRemaining < 30 {
+				expiringIn30DaysCertCount += 1
+			}
+			if daysRemaining < 90 {
+				expiringIn90DaysCertCount += 1
+			}
+		}
+	}
+	pm.CertificateRequests.Set(float64(csrCount))
+	pm.OutstandingCertificateRequests.Set(float64(outstandingCSRCount))
+	pm.Certificates.Set(float64(certCount))
+	pm.ExpiredCertificates.Set(float64(expiredCertCount))
+	pm.CertificatesExpiringIn1Day.Set(float64(expiringIn1DayCertCount))
+	pm.CertificatesExpiringIn7Days.Set(float64(expiringIn7DaysCertCount))
+	pm.CertificatesExpiringIn30Days.Set(float64(expiringIn30DaysCertCount))
+	pm.CertificatesExpiringIn90Days.Set(float64(expiringIn90DaysCertCount))
+}
+
+func certificateRequestsMetric() prometheus.Gauge {
+	metric := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "TODO",
+		Subsystem: "TODO",
+		Name:      "certificate_requests",
+		Help:      "Total number of certificate requests",
+	})
+	return metric
+}
+
+func outstandingCertificateRequestsMetric() prometheus.Gauge {
+	metric := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "TODO",
+		Subsystem: "TODO",
+		Name:      "outstanding_certificate_requests",
+		Help:      "Number of outstanding certificate requests",
+	})
+	return metric
+}
+
+func certificatesMetric() prometheus.Gauge {
+	metric := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "TODO",
+		Subsystem: "TODO",
+		Name:      "certificates",
+		Help:      "Total number of certificates provided to certificate requests",
+	})
+	return metric
+}
+
+func expiredCertificatesMetric() prometheus.Gauge {
+	metric := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "TODO",
+		Subsystem: "TODO",
+		Name:      "certificates_expired",
+		Help:      "Number of expired certificates",
+	})
+	return metric
+}
+
+func certificatesExpiringIn1DayMetric() prometheus.Gauge {
+	metric := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "TODO",
+		Subsystem: "TODO",
+		Name:      "certificates_expiring_in_1_day",
+		Help:      "Number of certificates expiring in less than 1 day",
+	})
+	return metric
+}
+
+func certificatesExpiringIn7DaysMetric() prometheus.Gauge {
+	metric := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "TODO",
+		Subsystem: "TODO",
+		Name:      "certificates_expiring_in_7_days",
+		Help:      "Number of certificates expiring in less than 7 days",
+	})
+	return metric
+}
+func certificatesExpiringIn30DaysMetric() prometheus.Gauge {
+	metric := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "TODO",
+		Subsystem: "TODO",
+		Name:      "certificates_expiring_in_30_days",
+		Help:      "Number of certificates expiring in less than 30 days",
+	})
+	return metric
+}
+
+func certificatesExpiringIn90DaysMetric() prometheus.Gauge {
+	metric := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "TODO",
+		Subsystem: "TODO",
+		Name:      "certificates_expiring_in_90_days",
+		Help:      "Number of certificates expiring in less than 90 days",
+	})
+	return metric
+}
+
+func certificateExpiryDate(certString string) time.Time {
+	certBlock, _ := pem.Decode([]byte(certString))
+	cert, _ := x509.ParseCertificate(certBlock.Bytes)
+	// TODO: cert.NotAfter can exist in a wrong cert. We should catch that at the db level validation
+	return cert.NotAfter
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -86,14 +86,14 @@ func newPrometheusMetrics() *PrometheusMetrics {
 // generateMetrics receives the live list of csrs to calculate the most recent values for the metrics
 // defined for prometheus
 func (pm *PrometheusMetrics) generateMetrics(csrs []certdb.CertificateRequest) {
-	var csrCount int = len(csrs)
-	var outstandingCSRCount int
-	var certCount int
-	var expiredCertCount int
-	var expiringIn1DayCertCount int
-	var expiringIn7DaysCertCount int
-	var expiringIn30DaysCertCount int
-	var expiringIn90DaysCertCount int
+	var csrCount float64 = float64(len(csrs))
+	var outstandingCSRCount float64
+	var certCount float64
+	var expiredCertCount float64
+	var expiringIn1DayCertCount float64
+	var expiringIn7DaysCertCount float64
+	var expiringIn30DaysCertCount float64
+	var expiringIn90DaysCertCount float64
 	for _, entry := range csrs {
 		if entry.Certificate == "" {
 			outstandingCSRCount += 1
@@ -122,14 +122,14 @@ func (pm *PrometheusMetrics) generateMetrics(csrs []certdb.CertificateRequest) {
 			}
 		}
 	}
-	pm.CertificateRequests.Set(float64(csrCount))
-	pm.OutstandingCertificateRequests.Set(float64(outstandingCSRCount))
-	pm.Certificates.Set(float64(certCount))
-	pm.ExpiredCertificates.Set(float64(expiredCertCount))
-	pm.CertificatesExpiringIn1Day.Set(float64(expiringIn1DayCertCount))
-	pm.CertificatesExpiringIn7Days.Set(float64(expiringIn7DaysCertCount))
-	pm.CertificatesExpiringIn30Days.Set(float64(expiringIn30DaysCertCount))
-	pm.CertificatesExpiringIn90Days.Set(float64(expiringIn90DaysCertCount))
+	pm.CertificateRequests.Set(csrCount)
+	pm.OutstandingCertificateRequests.Set(outstandingCSRCount)
+	pm.Certificates.Set(certCount)
+	pm.ExpiredCertificates.Set(expiredCertCount)
+	pm.CertificatesExpiringIn1Day.Set(expiringIn1DayCertCount)
+	pm.CertificatesExpiringIn7Days.Set(expiringIn7DaysCertCount)
+	pm.CertificatesExpiringIn30Days.Set(expiringIn30DaysCertCount)
+	pm.CertificatesExpiringIn90Days.Set(expiringIn90DaysCertCount)
 }
 
 func certificateRequestsMetric() prometheus.Gauge {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -14,8 +14,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-const ONE_SECOND = 1000000000
-
 type PrometheusMetrics struct {
 	http.Handler
 	registry                       *prometheus.Registry
@@ -40,9 +38,11 @@ func NewMetricsSubsystem(db *certdb.CertificateRequestsRepository) *PrometheusMe
 	}
 	metricsBackend := newPrometheusMetrics()
 	metricsBackend.generateMetrics(csrs)
+	ticker := time.NewTicker(120 * time.Second)
 	go func() {
-		time.Sleep(120 * ONE_SECOND)
-		metricsBackend.generateMetrics(csrs)
+		for range ticker.C {
+			metricsBackend.generateMetrics(csrs)
+		}
 	}()
 	metricsBackend.Handler = promhttp.HandlerFor(metricsBackend.registry, promhttp.HandlerOpts{})
 	return metricsBackend

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -86,7 +86,6 @@ func newPrometheusMetrics() *PrometheusMetrics {
 // generateMetrics receives the live list of csrs to calculate the most recent values for the metrics
 // defined for prometheus
 func (pm *PrometheusMetrics) generateMetrics(csrs []certdb.CertificateRequest) {
-	// TODO: This can run every 24 hours also to make sure we update the expiring in X day metrics.
 	var csrCount int = len(csrs)
 	var outstandingCSRCount int
 	var certCount int

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,11 +1,19 @@
 package metrics_test
 
 import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
 	"log"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/canonical/gocert/internal/certdb"
 	metrics "github.com/canonical/gocert/internal/metrics"
@@ -36,6 +44,110 @@ func TestPrometheusHandler(t *testing.T) {
 	if !strings.Contains(recorder.Body.String(), "go_goroutines") {
 		t.Errorf("handler returned an empty body")
 	}
+	err = db.Close()
+	if err != nil {
+		log.Fatalln(err)
+	}
+}
+
+// Generates a CSR and Certificate with the given days remaining
+func generateCertPair(daysRemaining int) (string, string) {
+	NotAfterTime := time.Now().AddDate(0, 0, daysRemaining)
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+
+	csrTemplate := x509.CertificateRequest{}
+	certTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotAfter:     NotAfterTime,
+	}
+
+	csrBytes, _ := x509.CreateCertificateRequest(rand.Reader, &csrTemplate, key)
+	certBytes, _ := x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, &key.PublicKey, key)
+
+	var buff bytes.Buffer
+	pem.Encode(&buff, &pem.Block{ //nolint:errcheck
+		Type:  "CERTIFICATE REQUEST",
+		Bytes: csrBytes,
+	})
+	csr := buff.String()
+	buff.Reset()
+	pem.Encode(&buff, &pem.Block{ //nolint:errcheck
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+	cert := buff.String()
+	return csr, cert
+}
+
+func initializeTestDB(db *certdb.CertificateRequestsRepository) {
+	for i, v := range []int{5, 10, 32} {
+		csr, cert := generateCertPair(v)
+		_, err := db.Create(csr)
+		if err != nil {
+			log.Fatalf("couldn't create test csr:%s", err)
+		}
+		_, err = db.Update(fmt.Sprint(i+1), cert)
+		if err != nil {
+			log.Fatalf("couldn't create test cert:%s", err)
+		}
+	}
+}
+
+// TestMetrics tests some of the metrics that we currently collect.
+func TestMetrics(t *testing.T) {
+	db, err := certdb.NewCertificateRequestsRepository(":memory:", "CertificateReq")
+	if err != nil {
+		log.Fatalln(err)
+	}
+	initializeTestDB(db)
+	m := metrics.NewMetricsSubsystem(db)
+
+	request, _ := http.NewRequest("GET", "/", nil)
+	recorder := httptest.NewRecorder()
+	m.Handler.ServeHTTP(recorder, request)
+
+	if status := recorder.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+	if recorder.Body.String() == "" {
+		t.Errorf("handler returned an empty body")
+	}
+	for _, line := range strings.Split(recorder.Body.String(), "\n") {
+		if strings.Contains(line, "outstanding_certificate_requests ") && !strings.HasPrefix(line, "#") {
+			if !strings.HasSuffix(line, "0") {
+				t.Errorf("outstanding_certificate_requests expected to receive 0")
+			}
+		} else if strings.Contains(line, "certificate_requests ") && !strings.HasPrefix(line, "#") {
+			if !strings.HasSuffix(line, "3") {
+				t.Errorf("certificate_requests expected to receive 3")
+			}
+		} else if strings.Contains(line, "certificates ") && !strings.HasPrefix(line, "#") {
+			if !strings.HasSuffix(line, "3") {
+				t.Errorf("certificates expected to receive 3")
+			}
+		} else if strings.Contains(line, "certificates_expired ") && !strings.HasPrefix(line, "#") {
+			if !strings.HasSuffix(line, "0") {
+				t.Errorf("certificates_expired expected to receive 0")
+			}
+		} else if strings.Contains(line, "certificates_expiring_in_1_day ") && !strings.HasPrefix(line, "#") {
+			if !strings.HasSuffix(line, "0") {
+				t.Errorf("certificates_expiring_in_1_day expected to receive 0")
+			}
+		} else if strings.Contains(line, "certificates_expiring_in_7_days ") && !strings.HasPrefix(line, "#") {
+			if !strings.HasSuffix(line, "1") {
+				t.Errorf("certificates_expiring_in_7_days expected to receive 1")
+			}
+		} else if strings.Contains(line, "certificates_expiring_in_30_days ") && !strings.HasPrefix(line, "#") {
+			if !strings.HasSuffix(line, "2") {
+				t.Errorf("certificates_expiring_in_30_days expected to receive 2")
+			}
+		} else if strings.Contains(line, "certificates_expiring_in_90_days ") && !strings.HasPrefix(line, "#") {
+			if !strings.HasSuffix(line, "3") {
+				t.Errorf("certificates_expiring_in_90_days expected to receive 3")
+			}
+		}
+	}
+
 	err = db.Close()
 	if err != nil {
 		log.Fatalln(err)

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -94,7 +95,14 @@ func initializeTestDB(t *testing.T, db *certdb.CertificateRequestsRepository) {
 
 // TestMetrics tests some of the metrics that we currently collect.
 func TestMetrics(t *testing.T) {
-	db, err := certdb.NewCertificateRequestsRepository(":memory:", "CertificateReq")
+	f, err := os.CreateTemp("./","*.db")
+	fmt.Print(f.Name())
+	if err != nil {
+		t.Fatal("couldn't create temp db file: "+ err.Error())
+	}
+	defer f.Close()
+	defer os.Remove(f.Name())
+	db, err := certdb.NewCertificateRequestsRepository(f.Name(), "CertificateReq")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"log"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -23,7 +22,7 @@ import (
 func TestPrometheusHandler(t *testing.T) {
 	db, err := certdb.NewCertificateRequestsRepository(":memory:", "CertificateReq")
 	if err != nil {
-		log.Fatalln(err)
+		t.Fatal(err)
 	}
 	m := metrics.NewMetricsSubsystem(db)
 
@@ -46,7 +45,7 @@ func TestPrometheusHandler(t *testing.T) {
 	}
 	err = db.Close()
 	if err != nil {
-		log.Fatalln(err)
+		t.Fatal(err)
 	}
 }
 
@@ -79,16 +78,16 @@ func generateCertPair(daysRemaining int) (string, string) {
 	return csr, cert
 }
 
-func initializeTestDB(db *certdb.CertificateRequestsRepository) {
+func initializeTestDB(t *testing.T, db *certdb.CertificateRequestsRepository) {
 	for i, v := range []int{5, 10, 32} {
 		csr, cert := generateCertPair(v)
 		_, err := db.Create(csr)
 		if err != nil {
-			log.Fatalf("couldn't create test csr:%s", err)
+			t.Fatalf("couldn't create test csr:%s", err)
 		}
 		_, err = db.Update(fmt.Sprint(i+1), cert)
 		if err != nil {
-			log.Fatalf("couldn't create test cert:%s", err)
+			t.Fatalf("couldn't create test cert:%s", err)
 		}
 	}
 }
@@ -97,9 +96,9 @@ func initializeTestDB(db *certdb.CertificateRequestsRepository) {
 func TestMetrics(t *testing.T) {
 	db, err := certdb.NewCertificateRequestsRepository(":memory:", "CertificateReq")
 	if err != nil {
-		log.Fatalln(err)
+		t.Fatal(err)
 	}
-	initializeTestDB(db)
+	initializeTestDB(t, db)
 	m := metrics.NewMetricsSubsystem(db)
 	csrs, _ := db.RetrieveAll()
 	m.GenerateMetrics(csrs)
@@ -152,6 +151,6 @@ func TestMetrics(t *testing.T) {
 
 	err = db.Close()
 	if err != nil {
-		log.Fatalln(err)
+		t.Fatal(err)
 	}
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -101,6 +101,8 @@ func TestMetrics(t *testing.T) {
 	}
 	initializeTestDB(db)
 	m := metrics.NewMetricsSubsystem(db)
+	csrs, _ := db.RetrieveAll()
+	m.GenerateMetrics(csrs)
 
 	request, _ := http.NewRequest("GET", "/", nil)
 	recorder := httptest.NewRecorder()

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,17 +1,23 @@
 package metrics_test
 
 import (
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/canonical/gocert/internal/certdb"
 	metrics "github.com/canonical/gocert/internal/metrics"
 )
 
 // TestPrometheusHandler tests that the Prometheus metrics handler responds correctly to an HTTP request.
 func TestPrometheusHandler(t *testing.T) {
-	handler := metrics.NewPrometheusMetricsHandler()
+	db, err := certdb.NewCertificateRequestsRepository(":memory:", "CertificateReq")
+	if err != nil {
+		log.Fatalln(err)
+	}
+	m := metrics.NewMetricsSubsystem(db)
 
 	request, err := http.NewRequest("GET", "/", nil)
 	if err != nil {
@@ -19,7 +25,7 @@ func TestPrometheusHandler(t *testing.T) {
 	}
 
 	recorder := httptest.NewRecorder()
-	handler.ServeHTTP(recorder, request)
+	m.Handler.ServeHTTP(recorder, request)
 
 	if status := recorder.Code; status != http.StatusOK {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
@@ -29,5 +35,9 @@ func TestPrometheusHandler(t *testing.T) {
 	}
 	if !strings.Contains(recorder.Body.String(), "go_goroutines") {
 		t.Errorf("handler returned an empty body")
+	}
+	err = db.Close()
+	if err != nil {
+		log.Fatalln(err)
 	}
 }


### PR DESCRIPTION
# Description

This change introduces the collection of metrics for GoCert. These metrics are the ones described in the GoCert backend specification, and two metrics specific to the webserver: Total number of requests and Request Latency.

There are 2 main methods of collecting these metrics: 
* As middleware that can sit between the endpoint handlers and the request and responses, and record anything that happens.
* As a separate goroutine that periodically queries the DB to update the metrics.

There are pros and cons to doing either.

### Middleware

For the middleware method, the main pro is that there is visibility to every process the webserver does, whether that's auth, logs, or anything in the request and response objects. This is nice for collecting information about the webserver, like number of failed logins, IP addresses of the requests, internal server errors etc.

It is not a good idea to collect metrics about things where the source of truth is not the requests themselves. This couples the API to the metrics themselves (how do we know the deleted CSR was outstanding or not without passing this info specifically?), introduces complex code to correctly identify the resource being edited and may lead to desync issues with the data in the database and the metrics (if we fail to pass the outstanding or not information to the middleware).

### GoRoutine

For the goroutine method, the benefit is the fact that the metrics are collected from the source of truth, which means the metrics are always eventually consistent. It's also completely decoupled from the metrics endpoint, which means we get to make decisions about moving the handler to different ports or servers without messing with the metrics collection logic and vice versa.

The downside is, the cadence of the collection means there will need to be a balance between how up-to-date the metrics are at any given time and the amount of load and processing power we need to use from the host and the DB to collect these metrics. Considering the fact that certificates are low in number and the metrics for them change very infrequently, this is not a problem even if we choose to collect metrics every 6 hours.

This PR initializes the cadance value at 120 seconds. This can be set as a config option in the future.

In this PR there's examples of doing both, which should be chosen considering these factors when defining future metrics.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
