### PR TITLE
chore: use ubuntu 24.04 build base

### DIFF
--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -28,7 +28,7 @@ jobs:
           docker run -d -p 3000:3000 --name gocert gocert:latest
       - name: Load config
         run: |
-          docker exec gocert /bin/pebble mkdir /etc/config
+          docker exec gocert /usr/bin/pebble mkdir /etc/config
           docker cp key.pem gocert:/etc/config/key.pem
           docker cp cert.pem gocert:/etc/config/cert.pem
           docker cp config.yaml gocert:/etc/config/config.yaml

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: gocert
 base: bare
-build-base: ubuntu@22.04
+build-base: ubuntu@24.04
 version: '0.0.2'
 summary: A certificate management tool
 description: |
@@ -31,3 +31,4 @@ parts:
     stage-packages:
       - ca-certificates_data
       - libc6_libs
+      - base-files_lib


### PR DESCRIPTION
# Description

Bump the build base to Ubuntu 24.04. Here we also need to include the base-files_lib slice because starting Ubuntu 24.04, the 'base-files' package provides "bin" as a symlink to "usr/bin".

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
