### PR TITLE
chore: use skopeo from rockcraft

### DIFF
--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -11,13 +11,13 @@ jobs:
         uses: actions/checkout@v4
       - uses: canonical/craft-actions/rockcraft-pack@main
         id: rockcraft
-      
-      - name: Install Skopeo
-        run: |
-          sudo snap install skopeo --edge --devmode
+        with:
+          rockcraft-channel: edge
+  
       - name: Import the image to Docker registry
         run: |
-          sudo skopeo --insecure-policy copy oci-archive:${{ steps.rockcraft.outputs.rock }} docker-daemon:gocert:latest
+          sudo rockcraft.skopeo --insecure-policy copy oci-archive:${{ steps.rockcraft.outputs.rock }} docker-daemon:gocert:latest
+
       - name: Create files required by GoCert
         run: |
           printf 'key_path:  "/etc/config/key.pem"\ncert_path: "/etc/config/cert.pem"\ndb_path: "/etc/config/certs.db"\nport: 3000\npebble_notifications: true\n' > config.yaml

--- a/.github/workflows/publish-rock.yaml
+++ b/.github/workflows/publish-rock.yaml
@@ -17,9 +17,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install skopeo
+      - name: Install rockcraft
         run: |
-          sudo snap install --devmode --channel edge skopeo
+          sudo snap install rockcraft --classic --channel edge
+        
       - uses: actions/download-artifact@v4
         with:
           name: rock
@@ -29,7 +30,7 @@ jobs:
           image_name="$(yq '.name' rockcraft.yaml)"
           version="$(yq '.version' rockcraft.yaml)"
           rock_file=$(ls *.rock | tail -n 1)
-          sudo skopeo \
+          sudo rockcraft.skopeo \
             --insecure-policy \
             copy \
             oci-archive:"${rock_file}" \

--- a/.github/workflows/scan-rock.yaml
+++ b/.github/workflows/scan-rock.yaml
@@ -10,9 +10,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install skopeo
+      - name: Install rockcraft
         run: |
-          sudo snap install --devmode --channel edge skopeo
+          sudo snap install rockcraft --classic --channel edge
 
       - name: Install yq
         run: |
@@ -29,7 +29,7 @@ jobs:
           version="$(yq '.version' rockcraft.yaml)"
           echo "version=${version}" >> $GITHUB_ENV
           rock_file=$(ls *.rock | tail -n 1)
-          sudo skopeo \
+          sudo rockcraft.skopeo \
             --insecure-policy \
             copy \
             oci-archive:"${rock_file}" \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,6 @@ npm run lint
 ```bash
 rockcraft pack -v
 version=$(yq '.version' rockcraft.yaml)
-sudo skopeo --insecure-policy copy oci-archive:gocert_${version}_amd64.rock docker-daemon:gocert:${version}
+sudo rockcraft.skopeo --insecure-policy copy oci-archive:gocert_${version}_amd64.rock docker-daemon:gocert:${version}
 docker run gocert:${version}
 ```


### PR DESCRIPTION
# Description

Use skopeo from rockcraft. This addresses an issue where we were not able to copy the built OCI image to docker images. The skopeo version in the snap dates from 2019 (v1.13.3) as the one in rockcraft is more recent (v1.14.2)

## Logs

```
time="2024-06-14T18:40:29Z" level=fatal msg="writing blob: io: read/write on closed pipe"
```

## Reference

- https://github.com/canonical/rockcraft/pull/477


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
