### PR TITLE
fix: display accurate status code in logs

### DIFF
--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -3,6 +3,7 @@ package server
 import (
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/canonical/gocert/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -71,10 +72,15 @@ func metricsMiddleware(ctx *middlewareContext) middleware {
 func loggingMiddleware(ctx *middlewareContext) middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			clonedWwriter := newResponseWriter(w)
+			clonedWriter := newResponseWriter(w)
 			next.ServeHTTP(w, r)
-			log.Println(r.Method, r.URL.Path, clonedWwriter.statusCode, http.StatusText(clonedWwriter.statusCode))
-			ctx.responseStatusCode = clonedWwriter.statusCode
+
+			// Suppress logging for static files
+			if !strings.HasPrefix(r.URL.Path, "/_next") {
+				log.Println(r.Method, r.URL.Path, clonedWriter.statusCode, http.StatusText(clonedWriter.statusCode))
+			}
+
+			ctx.responseStatusCode = clonedWriter.statusCode
 		})
 	}
 }

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -73,7 +73,7 @@ func loggingMiddleware(ctx *middlewareContext) middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			clonedWriter := newResponseWriter(w)
-			next.ServeHTTP(w, r)
+			next.ServeHTTP(clonedWriter, r)
 
 			// Suppress logging for static files
 			if !strings.HasPrefix(r.URL.Path, "/_next") {


### PR DESCRIPTION
# Description

Here we improve logging in GoCert addressing two issues. One relates to quality and the other to quantity.

## Wrong status code displayed in logs

The status code in logs used to always be `200` even if the real returned status code was something else. Here we fix this and display the accurate status code.

### Before

```
2024/06/14 16:35:16 error: given csr already recorded
2024/06/14 16:35:16 POST /api/v1/certificate_requests 200 OK
```

### After

```
2024/06/14 16:33:59 error: given csr already recorded
2024/06/14 16:33:59 POST /api/v1/certificate_requests 400 Bad Request
```

## Too many uninteresting logs

We get rid of logging for http calls made to static javascript files. For every refresh on the certificate requests table, this reduces the number of logs from 11 to 2, making logs much easier to parse. 

### Before

```
2024/06/14 16:09:10 GET /certificate_requests.html 200 OK
2024/06/14 16:09:10 GET /_next/static/css/efa7a01a8ef9ae8c.css 200 OK
2024/06/14 16:09:10 GET /_next/static/chunks/webpack-e0624c04961519f3.js 200 OK
2024/06/14 16:09:10 GET /_next/static/chunks/main-app-0792e029292925d4.js 200 OK
2024/06/14 16:09:10 GET /_next/static/chunks/app/certificate_requests/page-24960fdc96dcfd92.js 200 OK
2024/06/14 16:09:10 GET /_next/static/chunks/fd9d1056-e3489de6ce1f07f6.js 200 OK
2024/06/14 16:09:10 GET /_next/static/chunks/23-73297105dcfb990a.js 200 OK
2024/06/14 16:09:10 GET /_next/static/chunks/app/layout-1493160c0556b270.js 200 OK
2024/06/14 16:09:10 GET /_next/static/chunks/751-95e1accbba036fd5.js 200 OK
2024/06/14 16:09:10 GET /_next/static/chunks/d4b8ea31-029129a9f57ea450.js 200 OK
2024/06/14 16:09:10 GET /api/v1/certificate_requests 200 OK
```

### After

```
2024/06/14 16:08:43 GET /certificate_requests.html 200 OK
2024/06/14 16:08:43 GET /api/v1/certificate_requests 200 OK
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
