### PR TITLE
chore: error messages and only returning generated passwords

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -329,7 +329,8 @@ func PostUserAccount(env *Environment) http.HandlerFunc {
 			logErrorAndWriteResponse("Username is required", http.StatusBadRequest, w)
 			return
 		}
-		if user.Password == "" {
+		var shouldGeneratePassword = user.Password == ""
+		if shouldGeneratePassword {
 			generatedPassword, err := generatePassword()
 			if err != nil {
 				logErrorAndWriteResponse("Failed to generate password", http.StatusInternalServerError, w)
@@ -367,7 +368,10 @@ func PostUserAccount(env *Environment) http.HandlerFunc {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		response, err := json.Marshal(map[string]any{"id": id, "password": user.Password})
+		response, err := json.Marshal(map[string]any{"id": id})
+		if shouldGeneratePassword {
+			response, err = json.Marshal(map[string]any{"id": id, "password": user.Password})
+		}
 		if err != nil {
 			logErrorAndWriteResponse("Error marshaling response", http.StatusInternalServerError, w)
 		}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -339,7 +339,7 @@ func PostUserAccount(env *Environment) http.HandlerFunc {
 		}
 		if !validatePassword(user.Password) {
 			logErrorAndWriteResponse(
-				"Password does not meet requirements. It must include at least one capital letter, one lowercase letter, and either a number or a symbol.",
+				"Password must have 8 or more characters, must include at least one capital letter, one lowercase letter, and either a number or a symbol.",
 				http.StatusBadRequest,
 				w,
 			)
@@ -412,7 +412,7 @@ func ChangeUserAccountPassword(env *Environment) http.HandlerFunc {
 		}
 		if !validatePassword(user.Password) {
 			logErrorAndWriteResponse(
-				"Password does not meet requirements. It must include at least one capital letter, one lowercase letter, and either a number or a symbol.",
+				"Password must have 8 or more characters, must include at least one capital letter, one lowercase letter, and either a number or a symbol.",
 				http.StatusBadRequest,
 				w,
 			)

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -107,10 +107,10 @@ const (
 	adminUser              = `{"username": "testadmin", "password": "Admin123"}`
 	validUser              = `{"username": "testuser", "password": "userPass!"}`
 	invalidUser            = `{"username": "", "password": ""}`
-	noPasswordUser         = `{"username": "nopass", "password": ""}`
+	noPasswordUser         = `{"username": "nopass"}`
 	adminUserNewPassword   = `{"id": 1, "password": "newPassword1"}`
 	userNewInvalidPassword = `{"id": 1, "password": "password"}`
-	userMissingPassword    = `{"id": 1, "password": ""}`
+	userMissingPassword    = `{"id": 1}`
 	adminUserWrongPass     = `{"username": "testadmin", "password": "wrongpass"}`
 	notExistingUser        = `{"username": "not_existing", "password": "user"}`
 )
@@ -392,7 +392,7 @@ func TestGoCertUsersHandlers(t *testing.T) {
 			method:   "POST",
 			path:     "/api/v1/accounts",
 			data:     adminUser,
-			response: "{\"id\":1,\"password\":\"Admin123\"}",
+			response: "{\"id\":1}",
 			status:   http.StatusCreated,
 		},
 		{
@@ -408,7 +408,7 @@ func TestGoCertUsersHandlers(t *testing.T) {
 			method:   "POST",
 			path:     "/api/v1/accounts",
 			data:     validUser,
-			response: "{\"id\":2,\"password\":\"userPass!\"}",
+			response: "{\"id\":2}",
 			status:   http.StatusCreated,
 		},
 		{
@@ -546,7 +546,7 @@ func TestLogin(t *testing.T) {
 			method:   "POST",
 			path:     "/api/v1/accounts",
 			data:     adminUser,
-			response: "{\"id\":1,\"password\":\"Admin123\"}",
+			response: "{\"id\":1}",
 			status:   http.StatusCreated,
 		},
 		{

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -472,7 +472,7 @@ func TestGoCertUsersHandlers(t *testing.T) {
 			method:   "POST",
 			path:     "/api/v1/accounts/1/change_password",
 			data:     userNewInvalidPassword,
-			response: "Password does not meet requirements. It must include at least one capital letter, one lowercase letter, and either a number or a symbol.",
+			response: "Password must have 8 or more characters, must include at least one capital letter, one lowercase letter, and either a number or a symbol.",
 			status:   http.StatusBadRequest,
 		},
 		{


### PR DESCRIPTION
# Description

There are 2 changes that did not make it to the users handlers PR's that have been added here:
added a message including the length of the password required
dont return pw if we already sent one

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
