### PR TITLE
feat: authentication middleware for the GoCert server

### DIFF
--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -43,7 +43,7 @@ jobs:
         id: test_notify
         run : |
           curl -XPOST -k -d '{"username":"admin", "password": "Admin1234"}' https://localhost:3000/api/v1/accounts
-          export ADMIN_TOKEN=(curl -XPOST -k -d '{"username":"admin", "password": "Admin1234"}' https://localhost:3000/login)
+          export ADMIN_TOKEN=$(curl -XPOST -k -d '{"username":"admin", "password": "Admin1234"}' https://localhost:3000/login)
           curl -XPOST -k -d '-----BEGIN CERTIFICATE REQUEST-----
           MIIC5zCCAc8CAQAwRzEWMBQGA1UEAwwNMTAuMTUyLjE4My41MzEtMCsGA1UELQwk
           MzlhY2UxOTUtZGM1YS00MzJiLTgwOTAtYWZlNmFiNGI0OWNmMIIBIjANBgkqhkiG

--- a/.github/workflows/build-rock.yaml
+++ b/.github/workflows/build-rock.yaml
@@ -42,6 +42,8 @@ jobs:
       - name: Test if pebble notify fires correctly
         id: test_notify
         run : |
+          curl -XPOST -k -d '{"username":"admin", "password": "Admin1234"}' https://localhost:3000/api/v1/accounts
+          export ADMIN_TOKEN=(curl -XPOST -k -d '{"username":"admin", "password": "Admin1234"}' https://localhost:3000/login)
           curl -XPOST -k -d '-----BEGIN CERTIFICATE REQUEST-----
           MIIC5zCCAc8CAQAwRzEWMBQGA1UEAwwNMTAuMTUyLjE4My41MzEtMCsGA1UELQwk
           MzlhY2UxOTUtZGM1YS00MzJiLTgwOTAtYWZlNmFiNGI0OWNmMIIBIjANBgkqhkiG
@@ -59,7 +61,7 @@ jobs:
           cAQXk3fvTWuikHiCHqqdSdjDYj/8cyiwCrQWpV245VSbOE0WesWoEnSdFXVUfE1+
           RSKeTRuuJMcdGqBkDnDI22myj0bjt7q8eqBIjTiLQLnAFnQYpcCrhc8dKU9IJlv1
           H9Hay4ZO9LRew3pEtlx2WrExw/gpUcWM8rTI
-          -----END CERTIFICATE REQUEST-----' 'https://localhost:3000/api/v1/certificate_requests'
+          -----END CERTIFICATE REQUEST-----' -H "Authorization: Bearer $ADMIN_TOKEN" 'https://localhost:3000/api/v1/certificate_requests'
           curl -XPOST -k -d '-----BEGIN CERTIFICATE-----
           MIIDrDCCApSgAwIBAgIURKr+jf7hj60SyAryIeN++9wDdtkwDQYJKoZIhvcNAQEL
           BQAwOTELMAkGA1UEBhMCVVMxKjAoBgNVBAMMIXNlbGYtc2lnbmVkLWNlcnRpZmlj
@@ -81,7 +83,7 @@ jobs:
           gCX3nqYpp70oZIFDrhmYwE5ij5KXlHD4/1IOfNUKCDmQDgGPLI1tVtwQLjeRq7Hg
           XVelpl/LXTQawmJyvDaVT/Q9P+WqoDiMjrqF6Sy7DzNeeccWVqvqX5TVS6Ky56iS
           Mvo/+PAJHkBciR5Xn+Wg2a+7vrZvT6CBoRSOTozlLSM=
-          -----END CERTIFICATE-----' 'https://localhost:3000/api/v1/certificate_requests/1/certificate'
+          -----END CERTIFICATE-----' -H "Authorization: Bearer $ADMIN_TOKEN" 'https://localhost:3000/api/v1/certificate_requests/1/certificate'
           docker exec gocert /usr/bin/pebble notices
           docker exec gocert /usr/bin/pebble notices | grep gocert\\.com/certificate/update
           docker exec gocert /usr/bin/pebble notice 3

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -42,20 +42,20 @@ func NewGoCertRouter(env *Environment) http.Handler {
 	apiV1Router.HandleFunc("DELETE /accounts/{id}", DeleteUserAccount(env))
 	apiV1Router.HandleFunc("POST /accounts/{id}/change_password", ChangeUserAccountPassword(env))
 
-	apiV1Router.HandleFunc("POST /login", Login(env))
-
 	m := metrics.NewMetricsSubsystem(env.DB)
 	frontendHandler := newFrontendFileServer()
 
 	router := http.NewServeMux()
+	router.HandleFunc("POST /login", Login(env))
 	router.HandleFunc("/status", HealthCheck)
 	router.Handle("/metrics", m.Handler)
 	router.Handle("/api/v1/", http.StripPrefix("/api/v1", apiV1Router))
 	router.Handle("/", frontendHandler)
 
 	ctx := middlewareContext{
-		metrics:   m,
-		jwtSecret: env.JWTSecret,
+		metrics:            m,
+		jwtSecret:          env.JWTSecret,
+		firstAccountIssued: false,
 	}
 	middleware := createMiddlewareStack(
 		authMiddleware(&ctx),

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -555,10 +555,12 @@ func validatePassword(password string) bool {
 
 // Helper function to generate a JWT
 func generateJWT(username string, jwtSecret []byte, permissions int) (string, error) {
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"username":    username,
-		"permissions": permissions,
-		"exp":         time.Now().Add(time.Hour * 1).Unix(),
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwtGocertClaims{
+		Username:    username,
+		Permissions: permissions,
+		StandardClaims: jwt.StandardClaims{
+			ExpiresAt: time.Now().Add(time.Hour * 1).Unix(),
+		},
 	})
 	tokenString, err := token.SignedString(jwtSecret)
 	if err != nil {
@@ -566,4 +568,10 @@ func generateJWT(username string, jwtSecret []byte, permissions int) (string, er
 	}
 
 	return tokenString, nil
+}
+
+type jwtGocertClaims struct {
+	Username    string `json:"username"`
+	Permissions int    `json:"permissions"`
+	jwt.StandardClaims
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -527,7 +527,7 @@ func TestLogin(t *testing.T) {
 	}
 	env := &server.Environment{}
 	env.DB = testdb
-	env.JWTSecret = "secret"
+	env.JWTSecret = []byte("secret")
 	ts := httptest.NewTLSServer(server.NewGoCertRouter(env))
 	defer ts.Close()
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -103,7 +103,7 @@ func authMiddleware(ctx *middlewareContext) middleware {
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/metrics") || strings.HasPrefix(r.URL.Path, "/status") || strings.HasPrefix(r.URL.Path, "/login") {
+			if !strings.HasPrefix(r.URL.Path, "/api/v1/") {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/canonical/gocert/internal/metrics"
@@ -108,8 +109,10 @@ func authMiddleware(ctx *middlewareContext) middleware {
 				return
 			}
 			if r.Method == "POST" && strings.HasSuffix(r.URL.Path, "accounts") && !ctx.firstAccountIssued {
-				ctx.firstAccountIssued = true
 				next.ServeHTTP(w, r)
+				if strings.HasPrefix(strconv.Itoa(ctx.responseStatusCode), "2") {
+					ctx.firstAccountIssued = true
+				}
 				return
 			}
 			authHeader := r.Header.Get("Authorization")

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -15,6 +15,7 @@ type middleware func(http.Handler) http.Handler
 type middlewareContext struct {
 	responseStatusCode int
 	metrics            *metrics.PrometheusMetrics
+	jwtSecret          []byte
 }
 
 // The responseWriterCloner struct wraps the http.ResponseWriter struct, and extracts the status

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -4,7 +4,6 @@ package server
 import (
 	"crypto/rand"
 	"crypto/tls"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"log"
@@ -18,7 +17,7 @@ import (
 type Environment struct {
 	DB                      *certdb.CertificateRequestsRepository
 	SendPebbleNotifications bool
-	JWTSecret               string
+	JWTSecret               []byte
 }
 
 func SendPebbleNotification(key, request_id string) error {
@@ -29,12 +28,12 @@ func SendPebbleNotification(key, request_id string) error {
 	return nil
 }
 
-func generateJWTSecret() (string, error) {
+func generateJWTSecret() ([]byte, error) {
 	bytes := make([]byte, 32)
 	if _, err := rand.Read(bytes); err != nil {
-		return "", fmt.Errorf("failed to generate JWT secret: %w", err)
+		return bytes, fmt.Errorf("failed to generate JWT secret: %w", err)
 	}
-	return hex.EncodeToString(bytes), nil
+	return bytes, nil
 }
 
 // NewServer creates an environment and an http server with handlers that Go can start listening to


### PR DESCRIPTION
# Description

This PR implements the authentication and permission functionality described in TE091. The `/metrics` and `/status` endpoints are left unauthenticated, as well as the first POST request to the `api/v1/accounts` endpoint. For more details, please read TE091.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
