### PR TITLE
chore: better admin delete protection & more info in the status endpoint

### DIFF
--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -761,8 +761,8 @@ func TestAuthorization(t *testing.T) {
 			path:     "/api/v1/accounts/1",
 			data:     "",
 			auth:     adminToken,
-			response: "error: can't delete admin account",
-			status:   http.StatusConflict,
+			response: "error: deleting an Admin account is not allowed.",
+			status:   http.StatusBadRequest,
 		},
 		{
 			desc:     "admin can delete nonuser",

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -128,10 +128,6 @@ func authMiddleware(ctx *middlewareContext) middleware {
 					return
 				}
 			}
-			if r.Method == "DELETE" && strings.HasSuffix(r.URL.Path, "accounts/1") {
-				logErrorAndWriteResponse("can't delete admin account", http.StatusConflict, w)
-				return
-			}
 			next.ServeHTTP(w, r)
 		})
 	}


### PR DESCRIPTION
# Description

This PR has 2 changes:

## The status endpoint now returns an initialized value
`Initialized` means the first admin user has been created for GoCert.

The reason to report this in status is because gocert behaves differently in a subtle way when it hasn't been initialized, namely the fact that no authentication is needed to create this first account. Clients including the frontend need a stable way to query for this information, and the status endpoint is a good place to report it.

## Admin delete protection
We previously blocked any `Delete` request to the user with the ID of 1 to prevent users from deleting the admin account. The issue with this is the fact that the user with account ID 1 may not always be the admin account.

While this assumption is true for the current GoCert, it may not remain true when different auth methods and database connectors are added in the future. This is simply more stable.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
