### PR TITLE
refactor: redirect page in the frontend

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -76,9 +76,7 @@ func newFrontendFileServer() http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
-		if strings.HasSuffix(path, "/") || path == "/" {
-			path = "/certificate_requests.html"
-		} else if !strings.Contains(path, ".") {
+		if !strings.HasSuffix(path, "/") && !strings.Contains(path, ".") {
 			path += ".html"
 		}
 		r.URL.Path = path

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -1,0 +1,7 @@
+"use client"
+import { useRouter } from "next/navigation"
+
+export default function FrontPage() {
+    const router = useRouter()
+    router.push("/certificate_requests")
+}


### PR DESCRIPTION
# Description

This PR moves the redirect mechanism from the backend to the frontend, which is a bit cleaner and fixes a bug where any url that ends with a slash (like `/users/` or `/alkshflgeh/`) redirects to the certificate_requests page.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
