### PR TITLE
fix: log to stdout

### DIFF
--- a/cmd/gocert/main.go
+++ b/cmd/gocert/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	log.SetOutput(os.Stderr)
+	log.SetOutput(os.Stdout)
 	configFilePtr := flag.String("config", "", "The config file to be provided to the server")
 	flag.Parse()
 	if *configFilePtr == "" {

--- a/cmd/gocert/main_test.go
+++ b/cmd/gocert/main_test.go
@@ -151,13 +151,13 @@ func TestGoCertFail(t *testing.T) {
 		}
 		flag.CommandLine = flag.NewFlagSet(tc.Name, flag.ExitOnError)
 		cmd := exec.Command("gocert", tc.Args...)
-		stderr, _ := cmd.StderrPipe()
+		stdout, _ := cmd.StdoutPipe()
 
 		if err := cmd.Start(); err != nil {
 			t.Errorf("Failed running command")
 		}
 
-		slurp, _ := io.ReadAll(stderr)
+		slurp, _ := io.ReadAll(stdout)
 
 		if err := cmd.Wait(); err == nil {
 			t.Errorf("Command did not fail")


### PR DESCRIPTION
# Description

Logging to stderr does not show up in pebble. This change makes Gocert log to stdout. Probably fixes #56

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
